### PR TITLE
remove delay when switching between single watches

### DIFF
--- a/client/components/AllWatches.js
+++ b/client/components/AllWatches.js
@@ -1,26 +1,33 @@
-import React from 'react';
+import React, { Component } from 'react';
 import { connect } from 'react-redux'
-import {withRouter, Link} from 'react-router-dom'
+import { withRouter, Link } from 'react-router-dom'
+import { resetWatch } from '../store'
 
-const Watches = (props) => {
-  const { watches } = props;
-  return (
-    <div>
-      {watches.map(watch => {
-        return (
-          <div key={watch.id}>
-            <Link to={`/watches/${watch.id}`}><h2>{watch.make} {watch.model}</h2></Link>
-            <ul>
-              <li>Year: {watch.year}</li>
-              <li>Complications: {watch.complications}</li>
-              <li>Image: {watch.imageUrl}</li>
-              <li>Price: {watch.price}</li>
-            </ul>
-          </div>
-        )
-      })}
-    </div>
-  )
+class AllWatches extends Component {
+  componentDidMount() {
+    this.props.resetWatch()
+  }
+
+  render() {
+    const { watches } = this.props;
+    return (
+      <div>
+        {watches.map(watch => {
+          return (
+            <div key={watch.id}>
+              <Link to={`/watches/${watch.id}`}><h2>{watch.make} {watch.model}</h2></Link>
+              <ul>
+                <li>Year: {watch.year}</li>
+                <li>Complications: {watch.complications}</li>
+                <li>Image: {watch.imageUrl}</li>
+                <li>Price: {watch.price}</li>
+              </ul>
+            </div>
+          )
+        })}
+      </div>
+    )
+  }
 }
 
 const mapStateToProps = (state) => {
@@ -29,4 +36,12 @@ const mapStateToProps = (state) => {
   }
 }
 
-export default connect(mapStateToProps)(Watches);
+const mapDispatchToProps = (dispatch) => {
+  return {
+    resetWatch() {
+      dispatch(resetWatch({loading: true}))
+    }
+  }
+}
+
+export default withRouter(connect(mapStateToProps, mapDispatchToProps)(AllWatches));

--- a/client/components/AllWatches.js
+++ b/client/components/AllWatches.js
@@ -39,7 +39,7 @@ const mapStateToProps = (state) => {
 const mapDispatchToProps = (dispatch) => {
   return {
     resetWatch() {
-      dispatch(resetWatch({loading: true}))
+      dispatch(resetWatch({ loading: true }))
     }
   }
 }

--- a/client/components/SingleWatch.js
+++ b/client/components/SingleWatch.js
@@ -11,7 +11,7 @@ class Watch extends Component {
   render() {
     const watch = this.props.watch;
     return (
-      <div>
+      !watch.loading && <div>
         <h2>{watch.make} {watch.model}</h2>
         <ul>
           <li>Complications: {watch.complications}</li>

--- a/client/store/watch.js
+++ b/client/store/watch.js
@@ -3,12 +3,15 @@ import axios from 'axios'
 /**
  * ACTION TYPES
  */
-const GET_WATCH = 'GET_WATCH';
+const GET_WATCH = 'GET_WATCH'
+//when going back to view all watches
+const RESET_WATCH = 'RESET_WATCH'
 
 /**
  * ACTION CREATORS
  */
-const getWatch = watch => ({type: GET_WATCH, watch})
+export const getWatch = watch => ({type: GET_WATCH, watch})
+export const resetWatch = watch => ({type: RESET_WATCH, watch})
 
 /**
  * THUNK CREATORS
@@ -24,9 +27,13 @@ export const fetchWatch = (watchId) =>
 /**
  * REDUCER
  */
-export default function (state = {}, action) {
+//add loading to only render the page after successful data fetch
+export default function (state = {loading: true}, action) {
   switch (action.type) {
     case GET_WATCH:
+      action.watch.loading = false;
+      return action.watch
+    case RESET_WATCH:
       return action.watch
     default:
       return state


### PR DESCRIPTION
Connect to #40 

Added a loading attribute so that the single watch component renders only after the data is successfully fetched.